### PR TITLE
updated documentation to note that DE mode is default

### DIFF
--- a/R/getInteractingGenes.R
+++ b/R/getInteractingGenes.R
@@ -128,7 +128,7 @@ getSpaceMarkersMetric <- function(interacting.genes){
 #'  "interaction" with every other pattern we want
 #' to study. The default value is "Pattern_1".
 #' @param    mode    SpaceMarkers mode of operation. Possible values are
-#'  "residual" (the default) or "DE".
+#'  "DE" (the default) or "residual".
 #' @param    minOverlap    a number that specifies the minimum overlap between
 #'  genes in two patterns to be considered for the statistical tests.
 #'  The default is 50.

--- a/man/getInteractingGenes.Rd
+++ b/man/getInteractingGenes.Rd
@@ -34,7 +34,7 @@ set of numbered columns named 'Pattern_1.....N'.}
 to study. The default value is "Pattern_1".}
 
 \item{mode}{SpaceMarkers mode of operation. Possible values are
-"residual" (the default) or "DE".}
+"DE" (the default) or "residual".}
 
 \item{optParams}{a matrix with dimensions 2 X N,
 where N is the number

--- a/man/getPairwiseInteractingGenes.Rd
+++ b/man/getPairwiseInteractingGenes.Rd
@@ -26,7 +26,7 @@ for each cell type. The column names must include 'x' and 'y' as well as a
 set of numbered columns named 'Pattern_1.....N'.}
 
 \item{mode}{SpaceMarkers mode of operation. Possible values are
-"residual" (the default) or "DE".}
+"DE" (the default) or "residual".}
 
 \item{optParams}{a matrix with dimensions 2 X N,
 where N is the number


### PR DESCRIPTION
Made default mode DE, because that can be run with many more upstream deconvolution methods. 