### PR TITLE
Updated getSpaceMarkersMetric

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: SpaceMarkers
 Title: Spatial Interaction Markers
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(
     person(given = "Atul", family = "Deshpande", email = "adeshpande@jhu.edu", role = c("aut", "cre"), comment = c(ORCID="0000-0001-5144-6924")),
     person(given = "Ludmila", family = "Danilova", email = "ldanilo1@jhmi.edu", role = "ctb"),

--- a/R/getInteractingGenes.R
+++ b/R/getInteractingGenes.R
@@ -83,17 +83,19 @@ getSpaceMarkersMetric <- function(interacting.genes){
     for (i in seq(1,length(interacting_genes)))
     {
         if (all(dim(interacting_genes[[i]])>1))   {
-            Zsign <- (2*(-1+((interacting_genes[[i]]$Dunn.zP1_Int<0)|
-                        (interacting_genes[[i]]$Dunn.zP2_Int<0))*1)+1)
-            Zmag <- (interacting_genes[[i]]$Dunn.zP1_Int)*
-                    (interacting_genes[[i]]$Dunn.zP2_Int)/
-                    (pmax(abs(interacting_genes[[i]]$Dunn.zP2_P1),1))
-                interacting_genes[[i]]$SpaceMarkersMetric <- Zsign*Zmag
-                od <- order(
-                    interacting_genes[[i]]$SpaceMarkersMetric,decreasing=TRUE)
-                interacting_genes[[i]] <- interacting_genes[[i]][od,]
-                interacting_genes[[i]] <- interacting_genes[[i]][!is.na(
-                    interacting_genes[[i]]$SpaceMarkersMetric),]
+          Zsign <- (2*(-1+((interacting_genes[[i]]$Dunn.zP1_Int<0) &
+                             (interacting_genes[[i]]$Dunn.zP2_Int<0))*1)+1)
+          Zmag <- abs((interacting_genes[[i]]$Dunn.zP1_Int)*
+                        (interacting_genes[[i]]$Dunn.zP2_Int))/
+            (pmax(abs(interacting_genes[[i]]$Dunn.zP2_P1),1))
+          Zmetric <- Zsign*Zmag
+          interacting_genes[[i]]$SpaceMarkersMetric <- sign(Zmetric) * 
+            log2(abs(Zmetric)+1)
+          od <- order(
+            interacting_genes[[i]]$SpaceMarkersMetric,decreasing=TRUE)
+          interacting_genes[[i]] <- interacting_genes[[i]][od,]
+          interacting_genes[[i]] <- interacting_genes[[i]][!is.na(
+            interacting_genes[[i]]$SpaceMarkersMetric),]
         }
     }
     return(interacting_genes)


### PR DESCRIPTION
Updated getSpaceMarkersMetric to Include AND in Zsign instead of OR and transformed the SpaceMarkersMetric with log2(abs()+1) to prevent skewing of the scale. Updated Package version