### PR TITLE
getSpatialParametersExternal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: SpaceMarkers
 Title: Spatial Interaction Markers
-Version: 1.1.5
+Version: 1.1.6
 Authors@R: c(
     person(given = "Atul", family = "Deshpande", email = "adeshpande@jhu.edu", role = c("aut", "cre"), comment = c(ORCID="0000-0001-5144-6924")),
     person(given = "Ludmila", family = "Danilova", email = "ldanilo1@jhmi.edu", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: SpaceMarkers
 Title: Spatial Interaction Markers
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(
     person(given = "Atul", family = "Deshpande", email = "adeshpande@jhu.edu", role = c("aut", "cre"), comment = c(ORCID="0000-0001-5144-6924")),
     person(given = "Ludmila", family = "Danilova", email = "ldanilo1@jhmi.edu", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: SpaceMarkers
 Title: Spatial Interaction Markers
-Version: 1.1.4
+Version: 1.1.5
 Authors@R: c(
     person(given = "Atul", family = "Deshpande", email = "adeshpande@jhu.edu", role = c("aut", "cre"), comment = c(ORCID="0000-0001-5144-6924")),
     person(given = "Ludmila", family = "Danilova", email = "ldanilo1@jhmi.edu", role = "ctb"),

--- a/R/getInteractingGenes.R
+++ b/R/getInteractingGenes.R
@@ -12,7 +12,6 @@ find_pattern_hotspots <- function(
         sigmaPair <- params["sigmaOpt"]
         kernelthreshold <- params["threshOpt"]
     }
-    
     allwin <- spatstat.geom::owin(
         xrange = c(min(spPatterns$x),max(spPatterns$x)),yrange =c(
             min(spPatterns$y),max(spPatterns$y)))
@@ -21,13 +20,11 @@ find_pattern_hotspots <- function(
         x=spPatterns$x,y = spPatterns$y, window = allwin,marks = patternVector)
     Kact1 <- spatstat.explore::Smooth(
         X, at = "points", sigma = sigmaPair[1], ...)
-    
     if (includeSelf == TRUE){
       Kact1 <- spPatterns[,patternName] + Kact1
     } else {
       Kact1 <- Kact1
     }
-    
     Karr1 <- vapply(seq(1,nullSamples),function(i){
         Xr<-X;
         spatstat.geom::marks(Xr) <- sample(spatstat.geom::marks(X));

--- a/R/getInteractingGenes.R
+++ b/R/getInteractingGenes.R
@@ -83,17 +83,19 @@ getSpaceMarkersMetric <- function(interacting.genes){
     for (i in seq(1,length(interacting_genes)))
     {
         if (all(dim(interacting_genes[[i]])>1))   {
-            Zsign <- (2*(-1+((interacting_genes[[i]]$Dunn.zP1_Int<0)|
-                        (interacting_genes[[i]]$Dunn.zP2_Int<0))*1)+1)
-            Zmag <- (interacting_genes[[i]]$Dunn.zP1_Int)*
-                    (interacting_genes[[i]]$Dunn.zP2_Int)/
-                    (pmax(abs(interacting_genes[[i]]$Dunn.zP2_P1),1))
-                interacting_genes[[i]]$SpaceMarkersMetric <- Zsign*Zmag
-                od <- order(
-                    interacting_genes[[i]]$SpaceMarkersMetric,decreasing=TRUE)
-                interacting_genes[[i]] <- interacting_genes[[i]][od,]
-                interacting_genes[[i]] <- interacting_genes[[i]][!is.na(
-                    interacting_genes[[i]]$SpaceMarkersMetric),]
+          Zsign <- (2*(-1+((interacting_genes[[i]]$Dunn.zP1_Int<0) &
+                             (interacting_genes[[i]]$Dunn.zP2_Int<0))*1)+1)
+          Zmag <- abs((interacting_genes[[i]]$Dunn.zP1_Int)*
+                        (interacting_genes[[i]]$Dunn.zP2_Int))/
+            (pmax(abs(interacting_genes[[i]]$Dunn.zP2_P1),1))
+          Zmetric <- Zsign*Zmag
+          interacting_genes[[i]]$SpaceMarkersMetric <- sign(Zmetric) * 
+            log2(abs(Zmetric)+1)
+          od <- order(
+            interacting_genes[[i]]$SpaceMarkersMetric,decreasing=TRUE)
+          interacting_genes[[i]] <- interacting_genes[[i]][od,]
+          interacting_genes[[i]] <- interacting_genes[[i]][!is.na(
+            interacting_genes[[i]]$SpaceMarkersMetric),]
         }
     }
     return(interacting_genes)

--- a/R/getInteractingGenes.R
+++ b/R/getInteractingGenes.R
@@ -4,10 +4,10 @@
 find_pattern_hotspots <- function(
         spPatterns, params = NULL, patternName = "Pattern_1",
         outlier = "positive",
-    nullSamples = 100,...){
+    nullSamples = 100,includeSelf = TRUE,...){
     if (is.null(params)){
         sigmaPair <- 10
-        kernelthreshold <- 2
+        kernelthreshold <- 3
     } else {
         sigmaPair <- params["sigmaOpt"]
         kernelthreshold <- params["threshOpt"]
@@ -21,6 +21,13 @@ find_pattern_hotspots <- function(
         x=spPatterns$x,y = spPatterns$y, window = allwin,marks = patternVector)
     Kact1 <- spatstat.explore::Smooth(
         X, at = "points", sigma = sigmaPair[1], ...)
+    
+    if (includeSelf == TRUE){
+      Kact1 <- spPatterns[,patternName] + Kact1
+    } else {
+      Kact1 <- Kact1
+    }
+    
     Karr1 <- vapply(seq(1,nullSamples),function(i){
         Xr<-X;
         spatstat.geom::marks(Xr) <- sample(spatstat.geom::marks(X));


### PR DESCRIPTION
Added a getSpatialParametersExternal function to allow the user to specify sigma for kernel width for smoothing and outlier threshold for hotspots. The default behavior is to pull the spot diameter from a 10xVisium .json file from the usual spatial folder created by Visium. Updated version number