### PR TITLE
fixing findGenesOfInterest to avoid NAs in SpaceMarkers output.

### DIFF
--- a/R/findGenesOfInterest.R
+++ b/R/findGenesOfInterest.R
@@ -125,7 +125,7 @@ findGenesOfInterest<-function(
     
     #readjust p-values for Dunn's test for the genes that passed the kruskal test
     if (length(ind)>0) {
-        if (length(ind)==1)
+        if (length(ind)==1) # no need of qvalue computation for one gene
             qDunn$qvalues[ind,] <- res_dunn_test[ind,4:6]
         else {
             qq<-qvalue::qvalue(res_dunn_test[ind,4:6],

--- a/R/findGenesOfInterest.R
+++ b/R/findGenesOfInterest.R
@@ -88,18 +88,30 @@ findGenesOfInterest<-function(
     
     pattern1 <- patnames[1]
     pattern2 <- patnames[2]
-    if (!is.null(goodGenes)){
-        subset_goodGenes <- intersect(rownames(testMat),goodGenes)
-        testMat <- testMat[subset_goodGenes,]
-        }
-
+    
     #we lose sparsity here, it is necessary for row tests (dunn, kruskal)
     testMat <- as.matrix(testMat)
+    
+    if (!is.null(goodGenes)){
+        subset_goodGenes <- intersect(rownames(testMat),goodGenes)
+    } else 
+        {
+        subset_goodGenes <- names(which(rowSums(testMat)>0))
+    }
+    testMat <- testMat[subset_goodGenes,]
 
     res_kruskal<- matrixTests::row_kruskalwallis(x=testMat,g=region)
+    
+    #adjust p-values for kruskal
     qq <- qvalue::qvalue(res_kruskal$pvalue,fdr.level = fdr.level,
                             pfdr = FALSE, pi0 = 1)
     res_kruskal <- cbind(res_kruskal,p.adj = qq$qvalues)
+    
+    #force res_kruskal statistics for zero variance genes to be 0 with p-value 1
+    zero_genes <- names(which(rowSums(testMat[,!is.na(region)])==0))
+    res_kruskal[zero_genes,c("df","statistic")] <- 0
+    res_kruskal[zero_genes,c("pvalue","p.adj")] <- 1
+    
     res_dunn_test <- row.dunn.test(in.data=testMat, region=region,
                                         pattern1=pattern1, pattern2=pattern2)
     rownames(res_dunn_test) <- rownames(res_kruskal)
@@ -113,12 +125,23 @@ findGenesOfInterest<-function(
     
     #readjust p-values for Dunn's test for the genes that passed the kruskal test
     if (length(ind)>0) {
-    qq<-qvalue::qvalue(res_dunn_test[ind,4:6],
-                       fdr.level=fdr.level,pfdr=FALSE,pi0 = 1)
-    qDunn$qvalues[ind,] <- qq$qvalue
+        if (length(ind)==1)
+            qDunn$qvalues[ind,] <- res_dunn_test[ind,4:6]
+        else {
+            qq<-qvalue::qvalue(res_dunn_test[ind,4:6],
+                fdr.level=fdr.level,pfdr=FALSE,pi0 = 1)
+            qDunn$qvalues[ind,] <- qq$qvalue   
+        }
     }
     res_dunn_test <- cbind(res_dunn_test,qDunn$qvalues)
     colnames(res_dunn_test)[7:9] <- paste0(colnames(res_dunn_test)[7:9],".adj")
+    
+    #force res_dunn_test statistics for zero genes to be 0 with p-values of 1.
+    res_dunn_test[zero_genes, c("zP1_Int","zP2_Int","zP2_P1")] <- 0
+    res_dunn_test[zero_genes, c("pval_1_Int","pval_2_Int","pval_2_1")] <- 1
+    res_dunn_test[zero_genes,c("pval_1_Int.adj",
+                                "pval_2_Int.adj",
+                                "pval_2_1.adj")] <- 1
     interactGenes <- buildInteractGenesdf(res_kruskal,res_dunn_test,ind,
                                           fdr.level,pattern1,pattern2,
                                           analysis)

--- a/tests/testthat/test-findGenesOfInterest.R
+++ b/tests/testthat/test-findGenesOfInterest.R
@@ -18,3 +18,31 @@ test_that("findGenesOfInterest handles no significant genes without error", {
     # Call the function and expect no errors
     expect_no_error(findGenesOfInterest(testMat, region = region, fdr.level = fdr))
 })
+
+test_that("findGenesOfInterest returns statistics for all non-zero genes", {
+    # Mock input data
+    fdr <- 0.05
+    testMat <- matrix(runif(80), nrow=8, ncol=20)
+    testMat <- rbind(testMat, matrix(0, nrow=4, ncol=20))  # Add 4 more rows
+    testMat[10, 6] <- .2; # Add 3 non-zero genes
+    testMat[11, 2] <- .4;
+    testMat[12,9] <- .3;
+    rownames(testMat) <- paste0("Gene", 1:12)
+    region <- factor(rep(c("Pattern1", "Pattern2", "Interacting"), length.out=20))
+    
+    region[c(2,6,9)] <- NA  # Set some spots to NA
+    region <- factor(region)
+    suppressWarnings(
+        sm_test <- findGenesOfInterest(testMat, region = region, fdr.level = fdr)
+    )
+    zero_genes <- c("Gene10", "Gene11", "Gene12")
+    coi <- c("KW.df","KW.statistic","KW.pvalue","KW.p.adj","Dunn.zP1_Int",
+                "Dunn.zP2_Int","Dunn.zP2_P1","Dunn.pval_1_Int",
+                "Dunn.pval_2_Int","Dunn.pval_2_1","Dunn.pval_1_Int.adj",
+                "Dunn.pval_2_Int.adj","Dunn.pval_2_1.adj")
+    # Check that all non-zero genes are included in the output
+    expect_equal(nrow(sm_test[[1]]), 11)
+    expect_equal(any(is.na(sm_test[[1]])), FALSE)
+    expect_equal(sum(abs(t(as.matrix(sm_test[[1]][zero_genes,coi])) 
+        - c(0,0,1,1,0,0,0,1,1,1,1,1,1))), 0)
+})


### PR DESCRIPTION
Earlier versions would cause NAs in SpaceMarkers output if a gene has zero expression in all 3 regions of interest. This could prevent calculation of downstream statistics for genes based on the IMscores. Here we force the results of the KW and Dunn test to be 0s with p-value of 1.