### PR TITLE
fix pipeline

### DIFF
--- a/nextflow/main.nf
+++ b/nextflow/main.nf
@@ -1,7 +1,7 @@
 process SPACEMARKERS {
   tag "$meta.id"
   label 'process_high_memory'
-  container 'ghcr.io/deshpandelab/spacemarkers:main'
+  container 'ghcr.io/deshpandelab/spacemarkers@sha256:9c06f8f9340bb5c51300dbf3bc4e803613a15e1bd349eae43d5a129462a13f4e'
 
   input:
     tuple val(meta), path(features), path(data)
@@ -26,7 +26,7 @@ process SPACEMARKERS {
     
     #load spatial coords from tissue positions, deconvolved patterns, and expression
     coords <- load10XCoords("$data")
-    features <- getSpatialFeatures("$features")
+    features <- get_spatial_features("$features")
     dataMatrix <- load10XExpr("$data")
 
     #add spatial coordinates to deconvolved data, only use barcodes present in data
@@ -40,19 +40,19 @@ process SPACEMARKERS {
     dataMatrix <- dataMatrix[keepGenes, keepBarcodes]
 
     #compute optimal parameters for spatial patterns
-    optParams <- getSpatialParameters(spPatterns, visiumDir="$data");
+    optParams <- get_spatial_parameters(spPatterns, visiumDir="$data");
     saveRDS(optParams, file = "${prefix}/optParams.rds")
 
     #find hotspots in spatial patterns
-    hotspots <- findAllHotspots(spPatterns);
+    hotspots <- find_all_hotspots(spPatterns);
     saveRDS(hotspots, file = "${prefix}/hotspots.rds");
 
     #find regions of overlapping spatial patterns
-    overlaps <- getOverlapScores(hotspots);
+    overlaps <- calculate_overlap_undirected(hotspots);
     write.csv(overlaps, file = "${prefix}/overlapScores.csv", row.names = FALSE);
 
     #find genes that are differentially expressed in spatial patterns
-    spaceMarkers <- getPairwiseInteractingGenes(data = dataMatrix,
+    spaceMarkers <- get_pairwise_interacting_genes(data = dataMatrix,
                                                   optParams = optParams,
                                                   spPatterns = spPatterns,
                                                   hotspots = hotspots,
@@ -96,7 +96,7 @@ process SPACEMARKERS {
 process SPACEMARKERS_PLOTS {
   tag "$meta.id"
   label 'process_low'
-  container 'ghcr.io/deshpandelab/spacemarkers:main'
+  container 'ghcr.io/deshpandelab/spacemarkers@sha256:9c06f8f9340bb5c51300dbf3bc4e803613a15e1bd349eae43d5a129462a13f4e'
 
   input:
   tuple val(meta), path(spaceMarkers), path(overlapScores), val(source)
@@ -160,7 +160,7 @@ process SPACEMARKERS_PLOTS {
 process SPACEMARKERS_MQC {
   tag "$meta.id"
   label 'process_low'
-  container 'ghcr.io/deshpandelab/spacemarkers:main'
+  container 'ghcr.io/deshpandelab/spacemarkers@sha256:9c06f8f9340bb5c51300dbf3bc4e803613a15e1bd349eae43d5a129462a13f4e'
 
   input:
     tuple val(meta), path(spaceMarkers), val(source)

--- a/nextflow/main_hd.nf
+++ b/nextflow/main_hd.nf
@@ -1,13 +1,13 @@
 process SPACEMARKERS_HD {
   tag "$meta.id"
   label 'process_medium'
-  container 'ghcr.io/deshpandelab/spacemarkers:hdutils'
+  container 'ghcr.io/deshpandelab/spacemarkers@sha256:9c06f8f9340bb5c51300dbf3bc4e803613a15e1bd349eae43d5a129462a13f4e'
 
   input:
     tuple val(meta), path(features), path(data)
   output:
     tuple val(meta), path("${prefix}/IMscores.rds"),       val(source),   emit: IMscores
-    tuple val(meta), path("${prefix}/LRscores.rds"),       val(source),   emit: LRscores
+    tuple val(meta), path("${prefix}/LRscores.rds"),       val(source),   emit: LRscores, optional: true
     path  "versions.yml",                                                 emit: versions
 
    script:
@@ -41,7 +41,7 @@ process SPACEMARKERS_HD {
 process SPACEMARKERS_HD_PLOTS{
   tag "$meta.id"
   label 'process_low'
-  container 'ghcr.io/deshpandelab/spacemarkers:hdutils'
+  container 'ghcr.io/deshpandelab/spacemarkers@sha256:9c06f8f9340bb5c51300dbf3bc4e803613a15e1bd349eae43d5a129462a13f4e'
 
   input:
     tuple val(meta), path(lrscores), val(source)

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -8,6 +8,8 @@ params {
     max_time = '48.h'
 
     seed = 71237
+    use_ligand_receptor_genes = true
+    good_gene_threshold = 1000
 }
 
 //reporting

--- a/nextflow/templates/hdPipeline.R
+++ b/nextflow/templates/hdPipeline.R
@@ -44,11 +44,11 @@ patnames <- setdiff(colnames(spPatterns),c("x","y","barcode"))
 # Calculate hotspots and influence for each pattern
 print("Calculating hotspots and influence for each pattern...")
 patthresholds <- calculate_thresholds(spPatterns, minvals=0.1, maxvals=0.8)
-pat_hotspots <- find_all_hotspots(spPatterns, threshold=patthresholds)
+pat_hotspots <- find_hotspots_gmm(spPatterns, threshold=patthresholds)
 
 spInfluence <-  calculate_influence(spPatterns,optParams)
 infthresholds <- calculate_thresholds(spInfluence, minvals=0.01, maxvals=0.5)
-influence_hotspots <- find_all_hotspots(spInfluence, threshold=infthresholds)
+influence_hotspots <- find_hotspots_gmm(spInfluence, threshold=infthresholds)
 
 #create a table of pattern pairs
 pattern_pairs <- t(combn(patnames,2))

--- a/nextflow/templates/hdPipeline.R
+++ b/nextflow/templates/hdPipeline.R
@@ -24,16 +24,12 @@ patternpath <- "${features}"    # example: "rctd_cell_types.csv" #
 output_dir <- "${prefix}"       # example: "hd_pipeline_output" # 
 figure_dir <- file.path(output_dir, "figures")
 set.seed(${params.seed})
+useLigandReceptorGenes <- as.logical("${params.use_ligand_receptor_genes}") # limit to ligand-receptor genes
+goodgeneThreshold <- ${params.good_gene_threshold} # limit to genes with high expression
 
 
 dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
 dir.create(figure_dir, showWarnings = FALSE)
-
-# limit the analysis to ligand-receptor genes
-use.ligand.receptor.genes <- TRUE
-
-# limit the analysis to genes with high expression
-# goodgeneThreshold <- 1000
 
 coords <- load10XCoords(data_dir)
 rownames(coords) <- coords[["barcode"]]
@@ -60,41 +56,46 @@ pattern_pairs <- t(combn(patnames,2))
 data <- load10XExpr(data_dir)
 data <- data[,barcodes]
 
-data(lrdf)
-lrpairs <- lrdf[["interaction"]][,c("ligand.symbol","receptor.symbol")]
-ligands <- sapply(lrpairs[["ligand.symbol"]],function(i) strsplit(i,split=", "))
-receptors <- sapply(lrpairs[["receptor.symbol"]],function(i) strsplit(i,split=", "))
-names(ligands) <- names(receptors) <- rownames(lrpairs)
-
-lrgenes <- union(unlist(ligands),unlist(receptors))
-
-if (use.ligand.receptor.genes) {
+if (useLigandReceptorGenes) {
   print("Limiting data to ligand-receptor genes...")
     # Filter data to include only ligand-receptor genes
-    data <- data[rownames(data) %in% lrgenes,]
-} else{
-    # Use "good" genes
-    goodgenes <- which(apply(data,1,sum)>goodgeneThreshold)
-    data <- data[goodgenes,]
-}
+    library(CellChat)
+    lrdf <- CellChat::CellChatDB.human
+    lrpairs <- lrdf[["interaction"]][,c("ligand.symbol","receptor.symbol")]
+    ligands <- sapply(lrpairs[["ligand.symbol"]],function(i) strsplit(i,split=", "))
+    receptors <- sapply(lrpairs[["receptor.symbol"]],function(i) strsplit(i,split=", "))
+    names(ligands) <- names(receptors) <- rownames(lrpairs)
 
-# Calculate interaction scores for all pattern pairs
-IMscores <- calculate_gene_scores_directed(data=data, 
-                                pat_hotspots=pat_hotspots, 
-                                influence_hotspots=influence_hotspots, 
+    lrgenes <- union(unlist(ligands),unlist(receptors))
+    data <- data[rownames(data) %in% lrgenes,]
+
+    # Calculate interaction scores for all pattern pairs
+    IMscores <- calculate_gene_scores_directed(data=data,
+                                pat_hotspots=pat_hotspots,
+                                influence_hotspots=influence_hotspots,
                                 pattern_pairs=pattern_pairs,
                                 avoid_confounders=TRUE)
 
-saveRDS(IMscores, file = sprintf("%s/IMscores.rds", output_dir))
+    saveRDS(IMscores, file = sprintf("%s/IMscores.rds", output_dir))
 
-ligand_scores <- calculate_gene_set_score(IMscores,gene_sets = ligands, weighted = TRUE, method = "arithmetic_mean")
-receptor_scores <- calculate_gene_set_specificity(data, spPatterns, gene_sets=receptors, weighted = TRUE, method = "arithmetic_mean")
+    ligand_scores <- calculate_gene_set_score(IMscores,gene_sets = ligands, weighted = TRUE, method = "arithmetic_mean")
+    receptor_scores <- calculate_gene_set_specificity(data, spPatterns, gene_sets=receptors, weighted = TRUE, method = "arithmetic_mean")
+    lr_scores <- calculate_lr_scores(ligand_scores,receptor_scores,lr_pairs=lrpairs, method = "geometric_mean", weighted = TRUE)
 
-lr_scores <- calculate_lr_scores(ligand_scores,receptor_scores,lr_pairs=lrpairs, method = "geometric_mean", weighted = TRUE)
-
-saveRDS(ligand_scores, file = sprintf("%s/ligand_scores.rds", output_dir))
-saveRDS(receptor_scores, file = sprintf("%s/receptor_scores.rds", output_dir))
-saveRDS(lr_scores, file = sprintf("%s/LRscores.rds", output_dir))
+    saveRDS(ligand_scores, file = sprintf("%s/ligand_scores.rds", output_dir))
+    saveRDS(receptor_scores, file = sprintf("%s/receptor_scores.rds", output_dir))
+    saveRDS(lr_scores, file = sprintf("%s/LRscores.rds", output_dir))
+} else {
+    # Use top "good" genes
+    goodgenes <- apply(data,1,sum) |> sort(decreasing=TRUE) |> head(goodgeneThreshold) |> names()
+    data <- data[goodgenes,]
+    IMscores <- calculate_gene_scores_directed(data=data,
+                                pat_hotspots=pat_hotspots,
+                                influence_hotspots=influence_hotspots,
+                                pattern_pairs=pattern_pairs,
+                                avoid_confounders=TRUE)
+    saveRDS(IMscores, file = sprintf("%s/IMscores.rds", output_dir))
+}
 
 
 #output versions


### PR DESCRIPTION
This pull request updates the `spacemarkers` pipeline to improve reproducibility, flexibility, and gene selection logic. The most important changes include pinning all container images to a specific digest for reproducibility, updating function calls to use new snake_case naming conventions, and adding configurable parameters for ligand-receptor gene filtering and gene expression thresholds. Additionally, the logic for gene selection in the HD pipeline is now controlled by pipeline parameters.

**Reproducibility and Container Management:**
- All references to the `spacemarkers` container in Nextflow processes are now pinned to a specific image digest (`sha256:9c06f8f...`) instead of using floating tags. This ensures consistent environments across runs. [[1]](diffhunk://#diff-cfa29ee69f61161e68f45ce0d4b59be05f6333115c6c336c9afda1d2a0d36e65L4-R4) [[2]](diffhunk://#diff-cfa29ee69f61161e68f45ce0d4b59be05f6333115c6c336c9afda1d2a0d36e65L99-R99) [[3]](diffhunk://#diff-cfa29ee69f61161e68f45ce0d4b59be05f6333115c6c336c9afda1d2a0d36e65L163-R163) [[4]](diffhunk://#diff-9e8e3cdfc905a4ad94ed673e7314be3f381155b1ff09d97840e0e3cd6143df48L4-R10) [[5]](diffhunk://#diff-9e8e3cdfc905a4ad94ed673e7314be3f381155b1ff09d97840e0e3cd6143df48L44-R44)

**Function Naming Consistency:**
- Updated several R function calls in `main.nf` to use snake_case (e.g., `get_spatial_features`, `get_spatial_parameters`, `find_all_hotspots`, `calculate_overlap_undirected`, `get_pairwise_interacting_genes`) for consistency with updated codebase conventions. [[1]](diffhunk://#diff-cfa29ee69f61161e68f45ce0d4b59be05f6333115c6c336c9afda1d2a0d36e65L29-R29) [[2]](diffhunk://#diff-cfa29ee69f61161e68f45ce0d4b59be05f6333115c6c336c9afda1d2a0d36e65L43-R55)

**Parameterization and Flexibility:**
- Added new parameters `use_ligand_receptor_genes` (boolean) and `good_gene_threshold` (integer) to `nextflow.config` for controlling gene filtering behavior in the HD pipeline.

**Gene Selection Logic in HD Pipeline:**
- Refactored `hdPipeline.R` to use the new parameters: if `use_ligand_receptor_genes` is true, the analysis is restricted to ligand-receptor genes using the CellChat database; otherwise, the top `good_gene_threshold` most highly expressed genes are selected for analysis. [[1]](diffhunk://#diff-18476a11db0f3786dbfa8837bb2706c8531d33a3d276b6b316104c7d9de4205aR27-L37) [[2]](diffhunk://#diff-18476a11db0f3786dbfa8837bb2706c8531d33a3d276b6b316104c7d9de4205aL63-L79) [[3]](diffhunk://#diff-18476a11db0f3786dbfa8837bb2706c8531d33a3d276b6b316104c7d9de4205aL92-R98)

**Output Handling Improvements:**
- The `LRscores` output in the `SPACEMARKERS_HD` process is now marked as optional, reflecting that it may not always be produced depending on pipeline parameters.