### PR TITLE
chore(ci): bump container-build actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -25,7 +25,7 @@ jobs:
       # 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.0
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v4

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v5.0.0
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -25,10 +25,10 @@ jobs:
       # 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
@@ -44,7 +44,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -36,7 +36,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
@@ -44,7 +44,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

The `build-push-container` workflow on `main` started failing after the SME PR merge because every action it pinned was Node 20:

- `actions/checkout@v4` (Node 20) → bumped to `@v5` (Node 24)
- `docker/login-action@65b78e6e…` (effectively v3, Node 20) → `@v4` (Node 24)
- `docker/metadata-action@9ec57ed1…` (v5, Node 20) → `@v6` (Node 24)
- `docker/build-push-action@f2a1d5e9…` (v6, Node 20) → `@v7` (Node 24)

GitHub Actions deprecated Node 20 runtime, so the SHA pins to those older releases now fail with the deprecation message you saw.

## Notes

- Replaces the previous SHA pins with major-version tags. Docker maintains `v*` as moving major-version aliases (same convention `actions/checkout@v5` uses). Re-pin to immutable SHAs if you'd rather not trust the moving tag.
- `main.yml` calls `FertigLab/actions/.../r-build-check.yml@v1.3.0` — that's a reusable workflow you control upstream; if it's failing the same way, bump there too.

## Test plan

- [ ] Merge → confirm `build-push-container` workflow runs to completion
- [ ] Image lands on `ghcr.io/DeshpandeLab/SpaceMarkers` with the expected tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)