### PR TITLE
fix(ci): docker/login-action@v4.3.0 doesn't exist; pin to v4.1.0

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v5.0.0
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@v4.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

The container build on \`main\` failed with:

\`\`\`
Unable to resolve action \`docker/login-action@v4.3.0\`,
unable to find version \`v4.3.0\`
\`\`\`

A Copilot suggestion accepted in PR #93 changed \`docker/login-action@v4\` to \`@v4.3.0\`, but the latest published release of \`docker/login-action\` is **v4.1.0** — \`v4.3.0\` doesn't exist (verified via \`gh api repos/docker/login-action/releases\`).

This pins to the v4.1.0 commit SHA \`4907a6ddec9925e35a0a9e82d7399ccc52663121\`, matching the SHA-pinning style already used for the other two Docker actions on this line (\`docker/metadata-action@…030e8812 # v6.0.0\`, \`docker/build-push-action@…bcafcacb # v7.1.0\`).

## Test plan

- [ ] Merge → confirm \`build-push-container\` workflow run succeeds
- [ ] Image lands on \`ghcr.io/DeshpandeLab/SpaceMarkers\` with the expected tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)