### PR TITLE
fix(ci): authenticate ghcr.io with built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
## Summary

The container build is now reaching the login step but failing with:

```
Error response from daemon: Get "https://ghcr.io/v2/": denied: denied
```

The workflow was using a custom \`GHCR_TOKEN\` PAT secret that has either expired, lost the \`write:packages\` scope, or no longer matches \`github.actor\`.

This swaps the password to the built-in \`secrets.GITHUB_TOKEN\`. The workflow already declares the right scope:

```yaml
permissions:
  contents: read
  packages: write     # ← what GITHUB_TOKEN needs to push to ghcr.io
  attestations: write
  id-token: write
```

So \`GITHUB_TOKEN\` is auto-minted per run with \`packages: write\` — no PAT to manage, no expiry, no manual rotation when the original owner's permissions change.

## Follow-up after merge

The \`GHCR_TOKEN\` secret in repo **Settings → Secrets and variables → Actions** is no longer used and can be deleted whenever convenient.

## Test plan

- [ ] Merge → confirm \`build-push-container\` workflow succeeds
- [ ] Image lands on \`ghcr.io/DeshpandeLab/SpaceMarkers\` with the expected tags
- [ ] Optionally delete the unused \`GHCR_TOKEN\` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)